### PR TITLE
Docker sibling support

### DIFF
--- a/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
@@ -158,11 +158,11 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' "$(cat $WORKSPACE/docker_generating_docker/docker.cid)"' +
         ' &&',
         'docker cp' +
-        ' "$(cat $WORKSPACE/docker_generating_docker/docker.cid):/tmp/binarydeb"' +
+        ' "$(cat $WORKSPACE/docker_generating_docker/docker.cid):/tmp/binarydeb/."' +
         ' "$WORKSPACE/binarydeb"' +
         ' &&',
         'docker cp' +
-        ' "$(cat $WORKSPACE/docker_generating_docker/docker.cid):/tmp/docker_build_binarydeb"' +
+        ' "$(cat $WORKSPACE/docker_generating_docker/docker.cid):/tmp/docker_build_binarydeb/."' +
         ' "$WORKSPACE/docker_build_binarydeb"',
         'docker rm' +
         ' "$(cat $WORKSPACE/docker_generating_docker/docker.cid)"',
@@ -213,7 +213,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' "$(cat $WORKSPACE/docker_build_binarydeb/docker.cid)"' +
         ' &&',
         'docker cp' +
-        ' "$(cat $WORKSPACE/docker_build_binarydeb/docker.cid):/tmp/binarydeb"' +
+        ' "$(cat $WORKSPACE/docker_build_binarydeb/docker.cid):/tmp/binarydeb/."' +
         ' "$WORKSPACE/binarydeb"',
         'docker rm' +
         ' "$(cat $WORKSPACE/docker_build_binarydeb/docker.cid)"',

--- a/ros_buildfarm/templates/release/deb/sourcepkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/sourcepkg_job.xml.em
@@ -134,13 +134,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' "$(cat $WORKSPACE/docker_sourcedeb/docker.cid)"' +
         ' &&',
         'docker cp' +
-        ' "$(cat $WORKSPACE/docker_sourcedeb/docker.cid):/tmp/ros_buildfarm/."' +
-        ' "$WORKSPACE/ros_buildfarm"' +
-        ' &&',
-        'docker cp' +
         ' "$(cat $WORKSPACE/docker_sourcedeb/docker.cid):/tmp/sourcedeb/."' +
         ' "$WORKSPACE/sourcedeb"',
-        'docker rm ' +
+        'docker rm' +
         ' "$(cat $WORKSPACE/docker_sourcedeb/docker.cid)"',
         'echo "# END SECTION"',
     ]),


### PR DESCRIPTION
Fixed inability to run `ros_buildfarm release` in a docker container. This was caused by the buildfarm scripts attempting to bind-mount folders into the build containers, which works fine when running `ros_buildfarm` natively, but not when running `ros_buildfarm` in a docker container as well.

This is because the path provided to  `docker run -v` refers to a path on the host, so when the buildfarm container attempts to mount a local folder to a new container, if the folder it's trying to mount was also mounted to the buildfarm container then the paths do not line up.

For example:
- Host has a folder:
/home/builder/workspace/

- This gets mounted into the buildfarm container as:
/workspace/
  - Docker creates a link mapping the container's /workpace/ to the host's /home/builder/workspace/

- The buildfarm container creates some files, and then ros_buildfarm runs and spins off a sibling container.
- The sibling container is supposed to mount /workspace/my_package/ as:
/src/
  - \*\*\* Docker creates a link mapping the container's /src/ to the **host's** /workspace/my_package/ \*\*\*
  - This directory likely doesn't exist, and ros_buildfarm fails because the things it expects to be under /src/ are not there
  - Instead of mapping /home/builder/workspace/my_package to /src/, Docker mapped /workspace/my_package

We solve this issue by changing the relevant mounts to instead be a chain of `docker create && docker cp ... && docker start && docker cp ... ; docker rm`

